### PR TITLE
Fix Bug - Promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Built with basic HTML, CSS, and JavaScript.
 
 I try to write code that beginners can understand. Keep everything simple. Avoid being overly complex or caring too much about optimization.
 
+## 🕹️ Game Details
+
+- players **start at a rating of 400** when starting a new game
+- solving or failing a puzzle will change the player rating
+  - up to a **maximum of +/- 32**, based on the puzzle difficulty
+- player rating is stored via [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) 
+- puzzles are selected **randomly** from within **+/- 100** the player rating
+- in order to support **offline play**, approximately ~2 MB of puzzles
+  - stored in `/puzzles/offline/puzzles.csv`
+  - range in difficulty from **400 to 3166**
+  - puzzles were selected from [Lichess Open Database](https://database.lichess.org/#puzzles)
+- in a future update, support for the **[Lichess.org API](https://lichess.org/api)** is planned
+  - this will enable use of the entire puzzle database
+- [Pawn Promotion](https://en.wikipedia.org/wiki/Promotion_(chess)) is currently not supported.
+  - this will be added in a future update
+- the **current player rating** is visible in the **☰ menu**
+- clicking the **Puzzle ♟ Chess** title will reveal a **debug information**
+
 ## 🤝 Attribution
 
 - Pieces by [Cburnett](https://en.wikipedia.org/wiki/User:Cburnett), [CC BY-SA 3.0](http://creativecommons.org/licenses/by-sa/3.0/) via [Wikimedia Commons](https://commons.wikimedia.org/wiki/Template:SVG_chess_pieces)

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ I try to write code that beginners can understand. Keep everything simple. Avoid
   - puzzles were selected from [Lichess Open Database](https://database.lichess.org/#puzzles)
 - in a future update, support for the **[Lichess.org API](https://lichess.org/api)** is planned
   - this will enable use of the entire puzzle database
-- [Pawn Promotion](https://en.wikipedia.org/wiki/Promotion_(chess)) is currently not supported.
-  - this will be added in a future update
+- [pawn promotion](https://en.wikipedia.org/wiki/Promotion_(chess)) is supported
+  - but the piece will be automatically chosen based on the puzzle solution
 - the **current player rating** is visible in the **☰ menu**
-- clicking the **Puzzle ♟ Chess** title will reveal a **debug information**
+- double clicking the **Puzzle ♟ Chess** title will reveal a **debug information**
 
 ## 🤝 Attribution
 

--- a/script.js
+++ b/script.js
@@ -192,33 +192,23 @@ function computerMove(from, to) {
 }
 
 function playerMove(from, to) {
-    console.log('MOVE MOVE MOVE');
-    console.log(lastPuzzleMoveIndex);
-    console.log(currentPuzzle);
-    console.log(currentPuzzle.moves[lastPuzzleMoveIndex]);
-    console.log(currentPuzzle.moves[lastPuzzleMoveIndex+1]);
-    console.log(`${from}${to}`);
-    if(currentPuzzle.moves[lastPuzzleMoveIndex+1].slice(0,4) === `${from}${to}`) {
+    let best_move = currentPuzzle.moves[lastPuzzleMoveIndex+1];
+    // check if move is solution - slice to avoid possible promotion char
+    if(best_move.slice(0,4) === `${from}${to}`) {
         lastPuzzleMoveIndex++;
-        console.log(currentPuzzle.moves[lastPuzzleMoveIndex]);
-        // if move is length 5, it has promotion
-        if (currentPuzzle.moves[lastPuzzleMoveIndex].length === 5) {
-        console.log('GOOD GOOD GOOD 1' + currentPuzzle.moves[lastPuzzleMoveIndex].slice(4));
-            
-            puzzleMoveGood(from, to, currentPuzzle.moves[lastPuzzleMoveIndex].slice(4).toUpperCase());
+        // if best_move is length 5, it has promotion
+        if (best_move.length === 5) {
+            // grab char for promotion
+            puzzleMoveGood(from, to, best_move.slice(4));
         } else {
-        console.log('GOOD GOOD GOOD 2');
-
             puzzleMoveGood(from, to);
         }
     } else {
-        console.log('BAD BAD BAD');
         puzzleMoveBad(from, to);
     }
 }
 
 function puzzleMoveGood(from, to, promote = null) {
-    console.log(`from ${from} to ${to} promote ${promote}`);
     movePiece(from, to, promote);
     lastPuzzleMoveIndex++;
     if(currentStatus.isFinished || lastPuzzleMoveIndex >= currentPuzzle.moves.length) {
@@ -240,7 +230,6 @@ function puzzleMoveGood(from, to, promote = null) {
 function puzzleMoveBad(from, to) {
     const backupStatus = currentFEN;
     const backupPrevious = document.querySelectorAll('.previous');
-    console.log(backupPrevious);
     movePiece(from, to);
     updateMessage('There is a better move, try again.', 'bad');
     puzzle_solved_clean = false;
@@ -254,13 +243,15 @@ function puzzleMoveBad(from, to) {
 }
 
 function movePiece(from, to, promote = null) {
-    console.log(`move ${from} to ${to}`);
     game.move(from, to);
     if (promote) {
-        game.setPiece(to,promote);
+        if (currentStatus.turn === "white") {
+            game.setPiece(to,promote.toUpperCase());
+        } else {
+            game.setPiece(to,promote.toLowerCase());
+        }
     }
     currentStatus = game.exportJson();
-    console.log(currentStatus);
     currentFEN = game.exportFEN(currentStatus);
     loadBoard(currentFEN);
     document.getElementById(from).classList.add('previous');
@@ -270,9 +261,6 @@ function movePiece(from, to, promote = null) {
 const loadRandomPuzzle = () => {
     const minRating = Math.max(0, getLocalPlayerRating() - 100);
     const maxRating = getLocalPlayerRating() + 100;
-
-    console.log(minRating);
-    console.log(maxRating); 
 
     const eligibleRatings = Object.keys(puzzles).filter(rating => rating >= minRating && rating <= maxRating);
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,11 @@
+// https://github.com/jayasurian123/fen-validator
+// js-chess-engine currently lacks a validator so use this
 import validateFEN from './fen-validator/index.js';
-import { move, status, getFen }  from './js-chess-engine/lib/js-chess-engine.mjs';
+
+// https://github.com/josefjadrny/js-chess-engine
+// Option 1 - With in-memory (should allow us to deal with promotion)
+import { Game } from './js-chess-engine/lib/js-chess-engine.mjs';
+let game = new Game();
 
 const fenPositions = ['a8', 'b8', 'c8', 'd8', 'e8', 'f8', 'g8', 'h8', 'a7', 'b7', 'c7', 'd7', 'e7', 'f7', 'g7', 'h7', 'a6', 'b6', 'c6', 'd6', 'e6', 'f6', 'g6', 'h6', 'a5', 'b5', 'c5', 'd5', 'e5', 'f5', 'g5', 'h5', 'a4', 'b4', 'c4', 'd4', 'e4', 'f4', 'g4', 'h4', 'a3', 'b3', 'c3', 'd3', 'e3', 'f3', 'g3', 'h3', 'a2', 'b2', 'c2', 'd2', 'e2', 'f2', 'g2', 'h2', 'a1', 'b1', 'c1', 'd1', 'e1', 'f1', 'g1', 'h1'];
 const pieces = ['r', 'n', 'b', 'q', 'k', 'p', 'R', 'N', 'B', 'Q', 'K', 'P'];
@@ -234,9 +240,10 @@ function puzzleMoveBad(from, to) {
 
 function movePiece(from, to) {
     console.log(`move ${from} to ${to}`);
-    currentStatus = move(currentStatus, from.toUpperCase(), to.toUpperCase());
+    game.move(from, to);
+    currentStatus = game.exportJson();
     console.log(currentStatus);
-    currentFEN = getFen(currentStatus);
+    currentFEN = game.exportFEN(currentStatus);
     loadBoard(currentFEN);
     document.getElementById(from).classList.add('previous');
     document.getElementById(to).classList.add('previous');
@@ -274,8 +281,9 @@ function updateMessage(text, type = '') {
 function loadFen(fen) {
     if (validateFEN(fen)) {
         currentFEN = fen;
-        currentStatus = status(currentFEN);
-        loadBoard(fen);
+        game = new Game(currentFEN);
+        currentStatus = game.exportJson();
+        loadBoard(currentFEN);
     } else {
         console.log('invalid FEN');
     }

--- a/script.js
+++ b/script.js
@@ -98,7 +98,7 @@ function setUpButtons() {
     const menuButton = document.getElementById('menu-button');
     const closeButtons = document.querySelectorAll('.close-button');
 
-    title.addEventListener('pointerdown', function () {
+    title.addEventListener('dblclick', function () {
         let element = document.getElementById('debug'); 
         element.style.display = element.style.display === 'none' ? 'block' : 'none';
     });

--- a/script.js
+++ b/script.js
@@ -192,19 +192,34 @@ function computerMove(from, to) {
 }
 
 function playerMove(from, to) {
+    console.log('MOVE MOVE MOVE');
     console.log(lastPuzzleMoveIndex);
+    console.log(currentPuzzle);
     console.log(currentPuzzle.moves[lastPuzzleMoveIndex]);
+    console.log(currentPuzzle.moves[lastPuzzleMoveIndex+1]);
     console.log(`${from}${to}`);
     if(currentPuzzle.moves[lastPuzzleMoveIndex+1].slice(0,4) === `${from}${to}`) {
         lastPuzzleMoveIndex++;
-        puzzleMoveGood(from, to);
+        console.log(currentPuzzle.moves[lastPuzzleMoveIndex]);
+        // if move is length 5, it has promotion
+        if (currentPuzzle.moves[lastPuzzleMoveIndex].length === 5) {
+        console.log('GOOD GOOD GOOD 1' + currentPuzzle.moves[lastPuzzleMoveIndex].slice(4));
+            
+            puzzleMoveGood(from, to, currentPuzzle.moves[lastPuzzleMoveIndex].slice(4).toUpperCase());
+        } else {
+        console.log('GOOD GOOD GOOD 2');
+
+            puzzleMoveGood(from, to);
+        }
     } else {
+        console.log('BAD BAD BAD');
         puzzleMoveBad(from, to);
     }
 }
 
-function puzzleMoveGood(from, to) {
-    movePiece(from, to);
+function puzzleMoveGood(from, to, promote = null) {
+    console.log(`from ${from} to ${to} promote ${promote}`);
+    movePiece(from, to, promote);
     lastPuzzleMoveIndex++;
     if(currentStatus.isFinished || lastPuzzleMoveIndex >= currentPuzzle.moves.length) {
         updateMessage('<p>Puzzle complete!</p><p class="show">Click for next puzzle.</p>', 'good');
@@ -238,9 +253,12 @@ function puzzleMoveBad(from, to) {
     }, speed);
 }
 
-function movePiece(from, to) {
+function movePiece(from, to, promote = null) {
     console.log(`move ${from} to ${to}`);
     game.move(from, to);
+    if (promote) {
+        game.setPiece(to,promote);
+    }
     currentStatus = game.exportJson();
     console.log(currentStatus);
     currentFEN = game.exportFEN(currentStatus);

--- a/script.js
+++ b/script.js
@@ -26,8 +26,8 @@ window.addEventListener("DOMContentLoaded", (event) => {
     setUpButtons();
     params = getURLSearchParams();
 
-    // force set player rating if in params
-    if (params.get('rating') !== undefined) {
+    // force set player rating if in params and is a number
+    if (params.get('rating') != null && !isNaN(params.get('rating'))) {
         playerRating = params.get('rating');
         storeLocalPlayerRating(playerRating);
     } else {
@@ -38,7 +38,7 @@ window.addEventListener("DOMContentLoaded", (event) => {
         .then(response => response.text())
         .then(csvString => {
             puzzles = initPuzzles(csvString);
-            if (puzzles['param'] === undefined) {
+            if (puzzles['param'] == null) {
                 loadRandomPuzzle();
             } else {
                 loadPuzzle(puzzles['param']);

--- a/script.js
+++ b/script.js
@@ -189,7 +189,7 @@ function playerMove(from, to) {
     console.log(lastPuzzleMoveIndex);
     console.log(currentPuzzle.moves[lastPuzzleMoveIndex]);
     console.log(`${from}${to}`);
-    if(currentPuzzle.moves[lastPuzzleMoveIndex+1] === `${from}${to}`) {
+    if(currentPuzzle.moves[lastPuzzleMoveIndex+1].slice(0,4) === `${from}${to}`) {
         lastPuzzleMoveIndex++;
         puzzleMoveGood(from, to);
     } else {

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ let currentFEN = '';
 let currentStatus = '';
 let lastPuzzleMoveIndex = 0;
 let puzzles = {};
+let puzzle_from_param = '';
 let playerRating = 400;
 
 window.addEventListener("DOMContentLoaded", (event) => {
@@ -22,7 +23,11 @@ window.addEventListener("DOMContentLoaded", (event) => {
         .then(response => response.text())
         .then(csvString => {
             puzzles = initPuzzles(csvString);
-            loadRandomPuzzle();   
+            if (puzzle_from_param === '') {
+                loadRandomPuzzle();
+            } else {
+                loadPuzzle(puzzle_from_param);
+            }
         })
         .catch(error => {
             console.error('Error fetching puzzles:', error);
@@ -322,6 +327,7 @@ function updateGameInfo() {
 function initPuzzles(csvString) {
     const lines = csvString.split('\n');
     const puzzles = {};
+    const puzzleParam = getPuzzleParam();
 
     lines.forEach(line => {
         if (line.trim() !== '') {
@@ -333,6 +339,11 @@ function initPuzzles(csvString) {
         }
 
         puzzles[rating].push(puzzle);
+
+            // if a puzzle id was specified via URL
+            if (puzzleParam === puzzle_id) {
+                puzzle_from_param = puzzle;
+            }
         }
     });
 
@@ -367,4 +378,17 @@ function getLocalPlayerRating() {
         console.error("Error retrieving player rating:", error);
         return playerRating;
     }
+}
+
+function getPuzzleParam() {
+    // Get the full URL (Example: https://puzzlechess.ca/?puzzle=123456)
+    const url = new URL(window.location.href);
+
+    // Access the URLSearchParams object
+    const params = new URLSearchParams(url.search);
+
+    // Get values of 'puzzle' (Example: 123456)
+    const puzzle = params.get('puzzle');
+
+    return puzzle;
 }


### PR DESCRIPTION
Promotion has been fixed by:
- changing to using **js-chess-engine** [Option 1 with-in memory](https://github.com/josefjadrny/js-chess-engine?tab=readme-ov-file#option-1---with-in-memory)
- rather than creating a menu to pick which piece, just promote to what the puzzle wants
- this make it easier, but also will make theme-ing things later easier

URL parameters:
- you can now specify `puzzle` and `rating` via URL parameters
- examples: https://puzzlechess.ca?puzzle=0nSDR, https://puzzlechess.ca?rating=1000, https://puzzlechess.ca?puzzle=0nSDR&rating=1000
- if valid puzzle isn't found it will  load random
- if rating is not a number it will default to previous

Progress on #24 in that users can change rating via parameters, but I would still like them to be able to do so using an actual interface menu.

Closes #26 
Closes #25